### PR TITLE
Import github.com/dataence/bloom instead of github.com/zhenjl/bloom

### DIFF
--- a/partitioned/partitioned.go
+++ b/partitioned/partitioned.go
@@ -23,7 +23,7 @@ import (
 	"math"
 
 	"github.com/willf/bitset"
-	"github.com/zhenjl/bloom"
+	"github.com/dataence/bloom"
 )
 
 // PartitionedBloom is a variant implementation of the standard bloom filter.

--- a/partitioned/partitioned_test.go
+++ b/partitioned/partitioned_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"github.com/spaolacci/murmur3"
-	"github.com/zhenjl/bloom"
+	"github.com/dataence/bloom"
 	"github.com/zhenjl/cityhash"
 )
 

--- a/scalable/scalable.go
+++ b/scalable/scalable.go
@@ -20,8 +20,8 @@ import (
 	"hash/fnv"
 	"math"
 
-	"github.com/zhenjl/bloom"
-	"github.com/zhenjl/bloom/partitioned"
+	"github.com/dataence/bloom"
+	"github.com/dataence/bloom/partitioned"
 )
 
 // ScalableBloom is an implementation of the Scalable Bloom Filter that "addresses the problem of having

--- a/scalable/scalable_test.go
+++ b/scalable/scalable_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 
 	"github.com/spaolacci/murmur3"
-	"github.com/zhenjl/bloom"
-	"github.com/zhenjl/bloom/partitioned"
-	"github.com/zhenjl/bloom/standard"
+	"github.com/dataence/bloom"
+	"github.com/dataence/bloom/partitioned"
+	"github.com/dataence/bloom/standard"
 	"github.com/zhenjl/cityhash"
 )
 

--- a/standard/standard.go
+++ b/standard/standard.go
@@ -23,7 +23,7 @@ import (
 	"math"
 
 	"github.com/willf/bitset"
-	"github.com/zhenjl/bloom"
+	"github.com/dataence/bloom"
 )
 
 // StandardBloom is the classic bloom filter implementation

--- a/standard/standard_test.go
+++ b/standard/standard_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"github.com/spaolacci/murmur3"
-	"github.com/zhenjl/bloom"
+	"github.com/dataence/bloom"
 	"github.com/zhenjl/cityhash"
 )
 


### PR DESCRIPTION
There are a sub-packages that import "github.com/zhenjl/bloom" (old location) instead of "github.com/dataence/bloom" (new location). This could potentially cause a redundant checkout or even break the build process, if github's redirect function malfunctions.

